### PR TITLE
Fix 'Area code must be set before starting a session' error

### DIFF
--- a/Console/Command/ProcessQueueCommand.php
+++ b/Console/Command/ProcessQueueCommand.php
@@ -24,7 +24,11 @@ class ProcessQueueCommand extends Command
      */
     public function __construct(State $state, Queue $queue)
     {
+        $this->_state = $state;
         $this->_queue = $queue;
+
+        $state->setAreaCode('adminhtml');
+
         parent::__construct();
     }
 


### PR DESCRIPTION
Fix 'Area code not set: Area code must be set before starting a session' error when process a queued job.